### PR TITLE
Remove extra semicolon after Q_OBJECT

### DIFF
--- a/src/loginprocessor.h
+++ b/src/loginprocessor.h
@@ -16,7 +16,7 @@
 
 class PixivInterceptor : public QWebEngineUrlRequestInterceptor
 {
-    Q_OBJECT;
+    Q_OBJECT
 
     public:
         void interceptRequest(QWebEngineUrlRequestInfo &info) override;


### PR DESCRIPTION
This is unnecessary, and gets rid of the "warning: extra ';' inside a class" during compilation.