### PR TITLE
Add kwallet6 D-Bus access into flatpak manifest

### DIFF
--- a/io.github.micro.piki.json
+++ b/io.github.micro.piki.json
@@ -13,7 +13,8 @@
     "--share=network",
     "--socket=x11",
     "--socket=wayland",
-    "--device=dri"
+    "--device=dri",
+    "--talk-name=org.kde.kwalletd6"
   ],
   "separate-locales": false,
 


### PR DESCRIPTION
KWallet requires access to org.kde.kwalletd6 D-Bus to work.

This should fix:
`Couldn't start kwalletd:  QDBusError("org.freedesktop.DBus.Error.ServiceUnknown", "org.freedesktop.DBus.Error.ServiceUnknown")` on flatpak