### PR TITLE
Change the loading indicator to the standard Kirigami LoadingPlaceholder

### DIFF
--- a/src/contents/ui/Loading.qml
+++ b/src/contents/ui/Loading.qml
@@ -3,7 +3,6 @@
 
 import QtQuick
 import org.kde.kirigami as Kirigami
-import QtQuick.Controls as Controls
 import io.github.micro.piki
 
 Kirigami.Page {
@@ -43,12 +42,10 @@ Kirigami.Page {
         });
     }
 
-    Controls.BusyIndicator {
+    Kirigami.LoadingPlaceholder {
         id: loadingIndicator
-        opacity: 0
+
         anchors.centerIn: parent
-        width: Math.min(page.width, page.height) * 0.5
-        height: width
 
         Behavior on opacity {
             NumberAnimation {


### PR DESCRIPTION
This looks a big nicer than a giant rotating cog, and has the standard "Loading" text.

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/0210b624-3dc9-40e4-bd5f-1ab0f1f42dfd) | ![image](https://github.com/user-attachments/assets/0e1f594f-47b7-49d2-97fc-ac301e503700) |