### PR TITLE
Scrolling improvements

### DIFF
--- a/src/contents/controls/templates/FeedPage.qml
+++ b/src/contents/controls/templates/FeedPage.qml
@@ -6,13 +6,33 @@ import QtQuick.Layouts
 import QtQuick.Controls as Controls
 import org.kde.kirigami as Kirigami
 
-Kirigami.Page {
+Kirigami.ScrollablePage {
     id: fp
-    property alias flick: _flickable
+
     default property alias contentItems: columnLayout.data
     property bool loading: false
     signal fetchNext
     signal refresh
+
+    Connections {
+        target: fp.flickable
+
+        function onAtYEndChanged(): void {
+            if (!fp.flickable.atYEnd || fp.loading)
+                return;
+
+            fp.loading = true;
+            fp.fetchNext();
+        }
+    }
+
+    ColumnLayout {
+        id: columnLayout
+
+        anchors.fill: parent
+
+        spacing: Kirigami.Units.largeSpacing
+    }
 
     Kirigami.AbstractCard {
         z: 5
@@ -40,43 +60,14 @@ Kirigami.Page {
         from: 0
         to: -200
         opacity: value * -0.01
-        value: _flickable.contentY
+        value: fp.flickable.contentY
         onValueChanged: {
-            if (!_flickable.interactive && value == 0)
-                _flickable.interactive = true;
+            if (!fp.flickable.interactive && value == 0)
+                fp.flickable.interactive = true;
             if (value != to)
                 return;
-            _flickable.interactive = false;
+            fp.flickable.interactive = false;
             fp.refresh();
-        }
-    }
-    Flickable {
-        id: _flickable
-        anchors.fill: parent
-        contentWidth: columnLayout.width
-        contentHeight: columnLayout.implicitHeight
-        flickableDirection: Flickable.VerticalFlick
-        interactive: true
-        clip: true
-
-        onAtYEndChanged: {
-            if (!atYEnd || fp.loading)
-                return;
-
-            fp.loading = true;
-            fp.fetchNext();
-        }
-
-        ColumnLayout {
-            id: columnLayout
-            width: _flickable.width - sc.width
-            spacing: Kirigami.Units.largeSpacing
-        }
-
-        Controls.ScrollBar.vertical: Controls.ScrollBar {
-            id: sc
-            policy: Controls.ScrollBar.AlwaysOn
-            anchors.right: parent.right
         }
     }
 }

--- a/src/contents/ui/Collection.qml
+++ b/src/contents/ui/Collection.qml
@@ -64,7 +64,7 @@ FeedPage {
         columns: Math.floor((page.width - 25) / 190)
 
         Repeater {
-            model: page.feed.illusts
+            model: page.feed
             IllustrationButton {
                 required property variant modelData
                 illust: modelData

--- a/src/contents/ui/Following.qml
+++ b/src/contents/ui/Following.qml
@@ -75,7 +75,7 @@ FeedPage {
         columns: Math.floor((page.width - 25) / 190)
 
         Repeater {
-            model: page.feed.illusts
+            model: page.feed
             IllustrationButton {
                 required property var modelData
                 illust: modelData

--- a/src/contents/ui/Home.qml
+++ b/src/contents/ui/Home.qml
@@ -117,7 +117,7 @@ FeedPage {
         columns: Math.floor((page.width - 25) / 190)
 
         Repeater {
-            model: page.feed.illusts
+            model: page.feed
             IllustrationButton {
                 required property var modelData
                 illust: modelData

--- a/src/contents/ui/Home.qml
+++ b/src/contents/ui/Home.qml
@@ -85,17 +85,9 @@ FeedPage {
             }
         }
 
-        Flickable {
+        Controls.ScrollView {
             Layout.fillWidth: true
             Layout.minimumHeight: row.height + 25
-            contentWidth: row.width
-            interactive: row.width > page.width
-            clip: true
-
-            Controls.ScrollBar.horizontal: Controls.ScrollBar {
-                policy: Controls.ScrollBar.AsNeeded
-                anchors.bottom: parent.bottom
-            }
 
             RowLayout {
                 id: row

--- a/src/contents/ui/IllustView.qml
+++ b/src/contents/ui/IllustView.qml
@@ -293,7 +293,7 @@ Kirigami.Page {
                         columns: Math.floor(parent.width / 180)
 
                         Repeater {
-                            model: page.related.illusts
+                            model: page.related
                             IllustrationButton {
                                 required property var modelData
                                 illust: modelData

--- a/src/contents/ui/Newest.qml
+++ b/src/contents/ui/Newest.qml
@@ -65,7 +65,7 @@ FeedPage {
         columns: Math.floor((page.width - 25) / 190)
 
         Repeater {
-            model: page.feed.illusts
+            model: page.feed
             IllustrationButton {
                 required property var modelData
                 illust: modelData

--- a/src/contents/ui/Search.qml
+++ b/src/contents/ui/Search.qml
@@ -171,7 +171,7 @@ FeedPage {
         columns: Math.floor((page.width - 25) / 190)
 
         Repeater {
-            model: page.searchFeed.illusts
+            model: page.searchFeed
             IllustrationButton {
                 required property var modelData
                 illust: modelData


### PR DESCRIPTION
I noticed the scrolling was much slower than it should be (performance wise too) and so I did the following to combat that and it's much nicer on my machine:
* Switched to model-based illusts, although the fetching is still done on the QML side and involves throwing the list over to C++.
* Switched to ScrollViews and ScrollablePages, and let Kirigami patch up QML's terrible out-of-box scrolling.

Note that the piqi submodule has to be updated in the first commit once the dependent MR (https://github.com/MicrogamerCz/Piqi/pull/3) is merged.