### PR TITLE
Remove accidentally committed reference to WebAction

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -37,7 +37,6 @@ ecm_add_qml_module(piki_st
         contents/controls/TagChip.qml
         contents/controls/PremiumBanner.qml
         contents/controls/AccountsManager.qml
-        contents/controls/WebAction.qml
         contents/controls/RequestsCard.qml
         contents/controls/FlatAction.qml
         contents/controls/XWorkAsWallpaperOptions.qml


### PR DESCRIPTION
This is part of another branch, but it isn't present in master yet.