### PR TITLE
Use the filled favorite-favorited icon

### DIFF
--- a/src/contents/controls/IllustrationButton.qml
+++ b/src/contents/controls/IllustrationButton.qml
@@ -107,7 +107,15 @@ DoubleAbstractCard {
                         id: bookmarkIcon
                         z: 500
                         anchors.centerIn: parent
-                        source: (card.illust.isBookmarked < 2) ? "favorite" : "view-private"
+                        source: {
+                            if (card.illust.isBookmarked === 2) {
+                                return "view-private";
+                            } else if (card.illust.isBookmarked === 1) {
+                                return "favorite-favorited";
+                            } else {
+                                return "favorite";
+                            }
+                        }
                         color: (card.illust.isBookmarked > 0) ? "gold" : Kirigami.Theme.disabledTextColor
 
                         MouseArea {

--- a/src/contents/ui/IllustView.qml
+++ b/src/contents/ui/IllustView.qml
@@ -197,7 +197,15 @@ Kirigami.Page {
                                     checkable: true
                                     checked: page.illust.isBookmarked
                                     text: page.illust.totalBookmarks
-                                    icon.name: (page.illust.isBookmarked < 2) ? "favorite" : "view-private"
+                                    icon.name: {
+                                        if (page.illust.isBookmarked === 2) {
+                                            return "view-private";
+                                        } else if (page.illust.isBookmarked === 1) {
+                                            return "favorite-favorited";
+                                        } else {
+                                            return "favorite";
+                                        }
+                                    }
                                     icon.color: (page.illust.isBookmarked > 0) ? "gold" : Kirigami.Theme.textColor
 
                                     onTriggered: {


### PR DESCRIPTION
This makes favorited work look more distinct.

While testing this, I noticed that bookmarked work uses the wrong icon - which isn't caused by this patch.