### PR TITLE
Novels feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ TBD
 ```sh
 # Arch deps
 pacman -S kirigami-addons qt6-webview ki18n extra_cmake_modules kwallet kconfig futuresql qcoro
-# Piqi is additional package dependency. It's not on AUR yet, but there's a compiled binary and PKGBUILD in the source repo (https://github.com/MicrogamerCz/Piki)
+# Piqi is additional package dependency. It's not on AUR yet, but there's a compiled binary and PKGBUILD in the source repo (https://github.com/MicrogamerCz/Piqi)
 
 mkdir build && cd build
 cmake ..
@@ -89,7 +89,7 @@ TBD
   - [ ] Messages from web client
   - [ ] Implementing pixiv Fanbox (least important)
   - [ ] Posting new illusts/manga/novels (button will be in the top right corner)
-  - [ ] Novels overall
+  - [x] Novels overall
   - [ ] Account settings
   - [ ] my Pixiv page
   - [ ] Local browsing history (+ online for premium users)

--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ TBD
   - [ ] Cropping for "Set as wallpaper" share option when there's a mismatch between the aspect ratio of the image and the monitor
 - Profile page
   - [ ] More appropriate icon for fanbox link
+- Novel page
+  - Custom viewer parsed from the DOM
 - Welcome
   - [ ] Setup showing user the interface
   - [ ] Showing privacy policy popup (same as in the official app)(?)

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ TBD
   - [ ] Local browsing history (+ online for premium users)
   - [ ] Add Watchlist (aka following a manga or novel series)
   - [ ] Rewrite login process to remove dependency on QtWebEngine
+  - [ ] Cropping for "Set as wallpaper" share option when there's a mismatch between the aspect ratio of the image and the monitor
 - Profile page
   - [ ] More appropriate icon for fanbox link
 - Welcome

--- a/README.md
+++ b/README.md
@@ -89,7 +89,6 @@ TBD
   - [ ] Messages from web client
   - [ ] Implementing pixiv Fanbox (least important)
   - [ ] Posting new illusts/manga/novels (button will be in the top right corner)
-  - [x] Novels overall
   - [ ] Account settings
   - [ ] my Pixiv page
   - [ ] Local browsing history (+ online for premium users)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,6 +22,7 @@ ecm_add_qml_module(piki_st
         contents/ui/History.qml
         contents/ui/Welcome.qml
         contents/ui/ProfileView.qml
+        contents/ui/NovelView.qml
 
         contents/controls/Header.qml
         contents/controls/Sidebar.qml

--- a/src/contents/controls/Header.qml
+++ b/src/contents/controls/Header.qml
@@ -77,6 +77,17 @@ Item {
             });
         });
     }
+    function checkIfStringIsUrlAndProcess(str) {
+        try {
+            let url = new URL(str);
+            return str.substring(str.lastIndexOf("/") + 1);
+        } catch (_) {
+            if (!isNaN(str))
+                return str;
+            else
+                return "";
+        }
+    }
 
     Item {
         anchors.fill: parent
@@ -250,6 +261,16 @@ Item {
                                     pushSearchPage();
                                     return;
                                 }
+                                return;
+                            }
+                            let id = checkIfStringIsUrlAndProcess(text);
+                            if (id != "") {
+                                piqi.IllustDetail(Number(id)).then(il => {
+                                    navigateToPageParm("IllustView", {
+                                        illust: il
+                                    });
+                                });
+                                text = "";
                                 return;
                             }
 

--- a/src/contents/controls/IllustDetails.qml
+++ b/src/contents/controls/IllustDetails.qml
@@ -45,7 +45,9 @@ Kirigami.AbstractCard {
             Repeater {
                 model: card.illust.tags
 
-                TagChip {}
+                TagChip {
+                    onClicked: root.pushTagAndSearch(modelData)
+                }
             }
         }
     }

--- a/src/contents/controls/IllustrationButton.qml
+++ b/src/contents/controls/IllustrationButton.qml
@@ -30,6 +30,10 @@ DoubleAbstractCard {
             navigateToPageParm("IllustView", {
                 illust: card.illust
             });
+        else
+            piqi.FetchNovel(illust).then(nv => navigateToPageParm("NovelView", {
+                    novel: nv
+                }));
     }
     onBottomItemClicked: piqi.Details(card.illust.user).then(dtls => root.navigateToPageParm("ProfileView", {
             details: dtls

--- a/src/contents/controls/IllustrationButton.qml
+++ b/src/contents/controls/IllustrationButton.qml
@@ -14,7 +14,7 @@ DoubleAbstractCard {
     topHeight: 205
     bottomHeight: 45
     width: 175
-    property Illustration illust
+    property Work illust
     property bool hidden: false
 
     Kirigami.Theme.inherit: true
@@ -25,9 +25,12 @@ DoubleAbstractCard {
             piqi.BookmarkDetail(illust).then(details => illust.isBookmarked = (details.restriction == "private") ? 2 : 1);
     }
 
-    onTopItemClicked: navigateToPageParm("IllustView", {
-        illust: card.illust
-    })
+    onTopItemClicked: {
+        if (illust.novelAiType == undefined) // Simple check if the work is novel or not
+            navigateToPageParm("IllustView", {
+                illust: card.illust
+            });
+    }
     onBottomItemClicked: piqi.Details(card.illust.user).then(dtls => root.navigateToPageParm("ProfileView", {
             details: dtls
         }))

--- a/src/contents/controls/Sidebar.qml
+++ b/src/contents/controls/Sidebar.qml
@@ -110,7 +110,7 @@ Rectangle {
                     matchPart: true
                     onClicked: {
                         loading = true;
-                        piqi.FollowingFeed("illust", "all").then(following => {
+                        piqi.FollowingFeed("all").then(following => {
                             Cache.SynchroniseIllusts(following.illusts);
                             navigateToPageParm("Following", {
                                 feed: following
@@ -161,7 +161,7 @@ Rectangle {
 
                     onClicked: {
                         loading = true;
-                        piqi.BookmarksFeed("illust", false).then(bkmarks => {
+                        piqi.BookmarksFeed(false).then(bkmarks => {
                             Cache.SynchroniseIllusts(bkmarks.illusts);
                             navigateToPageParm("Collection", {
                                 feed: bkmarks

--- a/src/contents/controls/templates/DoubleAbstractCard.qml
+++ b/src/contents/controls/templates/DoubleAbstractCard.qml
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // SPDX-FileCopyrightText: 2025 Micro <microgamercz@proton.me>
 
+pragma ComponentBehavior: Bound
+
 import QtQuick
 import org.kde.kirigami as Kirigami
 import QtQuick.Controls as Controls
@@ -8,6 +10,8 @@ import QtQuick.Controls as Controls
 Rectangle {
     id: ilb
     height: topHeight + bottomHeight + 3
+
+    property bool vertical: true
 
     property alias topEnabled: delegateTop.hoverEnabled
     property alias topHeight: delegateTop.height

--- a/src/contents/controls/templates/FeedPage.qml
+++ b/src/contents/controls/templates/FeedPage.qml
@@ -141,7 +141,7 @@ Kirigami.ScrollablePage {
     }
 
     Shortcut {
-        sequence: StandardKey.Refresh
+        sequences: [StandardKey.Refresh]
         onActivated: {
             fp.flickable.contentY = 0;
             fp.refresh();

--- a/src/contents/controls/templates/FeedPage.qml
+++ b/src/contents/controls/templates/FeedPage.qml
@@ -139,4 +139,12 @@ Kirigami.ScrollablePage {
             }
         }
     }
+
+    Shortcut {
+        sequence: StandardKey.Refresh
+        onActivated: {
+            fp.flickable.contentY = 0;
+            fp.refresh();
+        }
+    }
 }

--- a/src/contents/ui/Collection.qml
+++ b/src/contents/ui/Collection.qml
@@ -16,10 +16,11 @@ FeedPage {
 
     property string tag: "All"
     onTagChanged: refresh()
-    property string category: "illust"
+    property bool isNovelCategory: false
+    onIsNovelCategoryChanged: refresh()
     property bool restrict: false
     onRestrictChanged: refresh()
-    property Illusts feed
+    property var feed
 
     function refresh() {
         page.flickable.contentY = 0;
@@ -30,11 +31,18 @@ FeedPage {
             queryTag = "";
         else if (queryTag == "Uncategorized")
             queryTag = "未分類";
-        piqi.BookmarksFeed(category, restrict, queryTag).then(rec => {
-            Cache.SynchroniseIllusts(rec.illusts);
-            feed = rec;
-            loading = false;
-        });
+        if (!isNovelCategory)
+            piqi.BookmarksFeed(restrict, queryTag).then(rec => {
+                Cache.SynchroniseIllusts(rec.illusts);
+                feed = rec;
+                loading = false;
+            });
+        else
+            piqi.NovelsBookmarksFeed(restrict, queryTag).then(rec => {
+                // Cache.SynchroniseIllusts(rec.illusts);
+                feed = rec;
+                loading = false;
+            });
     }
 
     Component.onCompleted: {
@@ -49,8 +57,8 @@ FeedPage {
     filterSelections: [
         SelectionButtons {
             id: categories
-            value: (page.category == "novel")
-            onValueChanged: page.category = value ? "novel" : "illust"
+            value: page.isNovelCategory
+            onValueChanged: page.isNovelCategory = value
             options: ["Illustrations / Manga", "Novels"]
         },
         Kirigami.Separator {
@@ -83,7 +91,6 @@ FeedPage {
         Repeater {
             model: page.feed
             IllustrationButton {
-                required property variant modelData
                 illust: modelData
             }
         }

--- a/src/contents/ui/Collection.qml
+++ b/src/contents/ui/Collection.qml
@@ -46,7 +46,7 @@ FeedPage {
     }
 
     Component.onCompleted: {
-        piqi.BookmarkIllustTags(restrict).then(tags_ => {
+        piqi.BookmarkIllustTags(isNovelCategory ? "novel" : "illust", restrict).then(tags_ => {
             tags.Extend(tags_);
         });
     }

--- a/src/contents/ui/Following.qml
+++ b/src/contents/ui/Following.qml
@@ -4,7 +4,6 @@
 import QtQuick
 import QtQuick.Layouts
 import QtQuick.Controls as Controls
-import org.kde.kirigami as Kirigami
 import io.github.micro.piki
 import io.github.micro.piqi
 import "../controls"
@@ -14,26 +13,34 @@ FeedPage {
     id: page
     title: `Following ・ ${categories.label}`
 
-    property string category: "illust"
+    property bool isNovelCategory: false
+    onIsNovelCategoryChanged: refresh()
     property string restrict: "all"
     onRestrictChanged: refresh()
-    property Illusts feed
+    property var feed
 
     function refresh() {
         page.flickable.contentY = 0;
         loading = true;
-        piqi.FollowingFeed(category, restrict).then(rec => {
-            Cache.SynchroniseIllusts(rec.illusts);
-            feed = rec;
-            loading = false;
-        });
+        if (!isNovelCategory)
+            piqi.FollowingFeed(restrict).then(rec => {
+                Cache.SynchroniseIllusts(rec.illusts);
+                feed = rec;
+                loading = false;
+            });
+        else
+            piqi.FollowingNovelsFeed(restrict).then(rec => {
+                // Cache.SynchroniseIllusts(rec.illusts);
+                feed = rec;
+                loading = false;
+            });
     }
 
     filterSelections: [
         SelectionButtons {
             id: categories
-            value: (page.category == "novel")
-            onValueChanged: page.category = value ? "novel" : "illust"
+            value: page.isNovelCategory
+            onValueChanged: page.isNovelCategory = value
             options: ["Illustrations / Manga", "Novels"]
         },
         Controls.BusyIndicator {
@@ -70,9 +77,11 @@ FeedPage {
         Repeater {
             model: page.feed
             IllustrationButton {
-                required property var modelData
                 illust: modelData
             }
         }
+    }
+    Item {
+        Layout.fillHeight: true
     }
 }

--- a/src/contents/ui/Home.qml
+++ b/src/contents/ui/Home.qml
@@ -15,8 +15,7 @@ FeedPage {
     title: `Home ・ ${categories.label}`
     property string category: "illust"
     onCategoryChanged: refresh()
-    property Recommended feed
-    property RecommendedNovels novelsFeed
+    property var feed
 
     function refresh() {
         page.flickable.contentY = 0;
@@ -24,13 +23,12 @@ FeedPage {
         if (category == "novel")
             piqi.RecommendedNovelsFeed(true, false).then(rec => {
                 // Cache.SynchroniseIllusts(rec.novels);
-                novelsFeed = rec;
-                // feed = rec;
+                feed = rec;
                 loading = false;
             });
         else
             piqi.RecommendedFeed(category, true, false).then(rec => {
-                Cache.SynchroniseIllusts(rec.illusts);
+                // Cache.SynchroniseIllusts(rec.illusts);
                 feed = rec;
                 loading = false;
             });
@@ -65,10 +63,6 @@ FeedPage {
         }
     ]
 
-    /*PremiumBanner {
-        visible: Config.enablePremiumSuggestions && !piqi.user.isPremium
-        }*/
-
     ColumnLayout {
         Layout.fillWidth: true
         spacing: Kirigami.Units.largeSpacing
@@ -95,10 +89,11 @@ FeedPage {
             RowLayout {
                 id: row
                 spacing: 15
+
                 Repeater {
-                    model: page.feed.rankingIllusts
+                    model: page.feed.ranking
+
                     IllustrationButton {
-                        required property var modelData
                         illust: modelData
                     }
                 }
@@ -107,34 +102,16 @@ FeedPage {
     }
 
     GridLayout {
-        // visible: page.category != "novel"
         rowSpacing: 15
         columnSpacing: 15
         columns: Math.floor((page.width - 25) / 190)
 
         Repeater {
-            model: (page.category != "novel") ? page.feed : page.novelsFeed
-            // model: page.feed
+            model: page.feed
 
             IllustrationButton {
-                required property var modelData
                 illust: modelData
             }
         }
     }
-    // GridLayout {
-    //     visible: page.category == "novel"
-    //     rowSpacing: 15
-    //     columnSpacing: 15
-    //     columns: Math.floor((page.width - 25) / 190)
-
-    //     Repeater {
-    //         model: page.novelsFeed
-
-    //         IllustrationButton {
-    //             required property var modelData
-    //             illust: modelData
-    //         }
-    //     }
-    // }
 }

--- a/src/contents/ui/Home.qml
+++ b/src/contents/ui/Home.qml
@@ -16,15 +16,24 @@ FeedPage {
     property string category: "illust"
     onCategoryChanged: refresh()
     property Recommended feed
+    property RecommendedNovels novelsFeed
 
     function refresh() {
         page.flickable.contentY = 0;
         loading = true;
-        piqi.RecommendedFeed(category, true, false).then(rec => {
-            Cache.SynchroniseIllusts(rec.illusts);
-            feed = rec;
-            loading = false;
-        });
+        if (category == "novel")
+            piqi.RecommendedNovelsFeed(true, false).then(rec => {
+                // Cache.SynchroniseIllusts(rec.novels);
+                novelsFeed = rec;
+                // feed = rec;
+                loading = false;
+            });
+        else
+            piqi.RecommendedFeed(category, true, false).then(rec => {
+                Cache.SynchroniseIllusts(rec.illusts);
+                feed = rec;
+                loading = false;
+            });
     }
 
     filterSelections: [
@@ -98,16 +107,34 @@ FeedPage {
     }
 
     GridLayout {
+        // visible: page.category != "novel"
         rowSpacing: 15
         columnSpacing: 15
         columns: Math.floor((page.width - 25) / 190)
 
         Repeater {
-            model: page.feed
+            model: (page.category != "novel") ? page.feed : page.novelsFeed
+            // model: page.feed
+
             IllustrationButton {
                 required property var modelData
                 illust: modelData
             }
         }
     }
+    // GridLayout {
+    //     visible: page.category == "novel"
+    //     rowSpacing: 15
+    //     columnSpacing: 15
+    //     columns: Math.floor((page.width - 25) / 190)
+
+    //     Repeater {
+    //         model: page.novelsFeed
+
+    //         IllustrationButton {
+    //             required property var modelData
+    //             illust: modelData
+    //         }
+    //     }
+    // }
 }

--- a/src/contents/ui/IllustView.qml
+++ b/src/contents/ui/IllustView.qml
@@ -13,7 +13,6 @@ import "../controls"
 // - change the way comments collapse, make the button visible only when comments > 1
 // - (OPTIONAL) fetching more arts from the artist
 // - clicking profile header will open profile
-// - clicking tags will open a query with that tag
 
 Kirigami.Page {
     id: page
@@ -249,7 +248,6 @@ Kirigami.Page {
                                 enabled: Config.allowR18WorksAsWallpapers != 2
                                 text: "Set as wallpaper"
                                 icon.name: "viewimage"
-                                // TODO: Custom passive notification (+ in the copy url above)
                                 onTriggered: wallpaperSelections.setup()
                             }
                         }
@@ -287,8 +285,6 @@ Kirigami.Page {
                     CommentSection {
                         illust: page.illust
                     }
-                    // TODO: opening profile by clicking profile card, support for following, support for comms info(?)
-                    // TODO: clicking on tabs will open a query
                     GridLayout {
                         rowSpacing: 15
                         columnSpacing: 15

--- a/src/contents/ui/Loading.qml
+++ b/src/contents/ui/Loading.qml
@@ -36,7 +36,7 @@ Kirigami.Page {
                 }
             case 1:
                 {
-                    piqi.FollowingFeed("illust", "all").then(following => {
+                    piqi.FollowingFeed("all").then(following => {
                         Cache.SynchroniseIllusts(following.illusts);
                         navigateToPageParm("Following", {
                             feed: following
@@ -66,7 +66,7 @@ Kirigami.Page {
                 }
             case 5:
                 {
-                    piqi.BookmarksFeed("illust", false).then(bkmarks => {
+                    piqi.BookmarksFeed(false).then(bkmarks => {
                         Cache.SynchroniseIllusts(bkmarks.illusts);
                         loadingIndicator.opacity = 0;
                         navigateToPageParm("Collection", {

--- a/src/contents/ui/Main.qml
+++ b/src/contents/ui/Main.qml
@@ -55,6 +55,12 @@ Kirigami.ApplicationWindow {
         id: piqi
     }
 
+    function pushTagAndSearch(tag) {
+        hd.selectedTags.append({
+            tagData: tag
+        });
+        hd.pushSearchPage();
+    }
     header: Header {
         id: hd
         visible: !sidebar.collapsed

--- a/src/contents/ui/Newest.qml
+++ b/src/contents/ui/Newest.qml
@@ -14,16 +14,23 @@ FeedPage {
     title: `Newest ・ ${categories.label}`
 
     property string category: "illust"
-    property Illusts feed
+    property var feed
 
     function refresh() {
         page.flickable.contentY = 0;
         loading = true;
-        piqi.LatestGlobal(category).then(rec => {
-            Cache.SynchroniseIllusts(rec.illusts);
-            feed = rec;
-            loading = false;
-        });
+        if (category !== "novel")
+            piqi.LatestGlobal(category).then(rec => {
+                Cache.SynchroniseIllusts(rec.illusts);
+                feed = rec;
+                loading = false;
+            });
+        else
+            piqi.LatestNovelsGlobal(rec => {
+                // Cache.SynchroniseIllusts(rec.illusts);
+                feed = rec;
+                loading = false;
+            });
     }
 
     filterSelections: [
@@ -59,9 +66,11 @@ FeedPage {
         Repeater {
             model: page.feed
             IllustrationButton {
-                required property var modelData
                 illust: modelData
             }
         }
+    }
+    Item {
+        Layout.fillHeight: true
     }
 }

--- a/src/contents/ui/Newest.qml
+++ b/src/contents/ui/Newest.qml
@@ -14,6 +14,7 @@ FeedPage {
     title: `Newest ・ ${categories.label}`
 
     property string category: "illust"
+    onCategoryChanged: refresh()
     property var feed
 
     function refresh() {

--- a/src/contents/ui/NovelView.qml
+++ b/src/contents/ui/NovelView.qml
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025 Micro <microgamercz@proton.me>
+
+import QtQuick
+import QtWebEngine
+import org.kde.kirigami as Kirigami
+import io.github.micro.piki
+import io.github.micro.piqi
+
+Kirigami.Page {
+    id: page
+    padding: 0
+    title: "piki"
+
+    property string novel
+    onNovelChanged: web.loadHtml(novel)
+
+    WebEngineView {
+        id: web
+        anchors.fill: parent
+        // backgroundColor: "#B7B7B7"
+        backgroundColor: "transparent"
+
+        profile: WebEngineProfile {
+            id: profile
+            httpAcceptLanguage: Qt.uiLanguage
+        }
+    }
+}

--- a/src/contents/ui/ProfileView.qml
+++ b/src/contents/ui/ProfileView.qml
@@ -316,7 +316,6 @@ FeedPage {
                     }
 
                     Controls.Label {
-                        // elide: Text.ElideRight
                         wrapMode: Text.WordWrap
                         visible: userDetailsSwitch.details == 1
                         text: page.user.comment


### PR DESCRIPTION
- Added NovelView for reading Novels (currently a direct WebEngineView)
- IllustPage is opened when work id or url is submitted into the search field
- Clicking Tag in IllustPage opens SearchPage with the tag as query
- Updated used Piqi API
- Abstracted Illust and Novels with Work component
- Added refresh keybind (F5) for feed pages
- Implemented Novels categories in feed pages