### PR TITLE
memory leak fix

### DIFF
--- a/src/contents/controls/Header.qml
+++ b/src/contents/controls/Header.qml
@@ -94,15 +94,62 @@ Item {
         anchors.leftMargin: 15
         anchors.margins: 5
 
-        Controls.Label {
-            id: headerLabel
+        RowLayout {
             anchors {
                 left: parent.left
                 verticalCenter: parent.verticalCenter
             }
-            text: root.currentPage
-            font.bold: true
-            font.pointSize: 14
+            spacing: 2
+
+            Controls.ToolButton {
+                icon.name: "go-previous"
+                icon.width: 24
+                icon.height: 24
+                flat: true
+                display: Controls.AbstractButton.IconOnly
+                implicitWidth: 40
+                implicitHeight: 40
+                enabled: root.pageStack.currentIndex > 0 && !root.fullscreenActive
+                onClicked: root.goBack()
+            }
+            Controls.Label {
+                id: headerLabel
+                text: root.currentPage
+                font.bold: true
+                font.pointSize: 14
+            }
+        }
+
+        Controls.Label {
+            id: resLabel
+            anchors {
+                right: forwardBtn.left
+                verticalCenter: parent.verticalCenter
+                rightMargin: 10
+            }
+            visible: root.pageStack.currentItem?.illust?.width !== undefined
+            text: (root.pageStack.currentItem?.illust?.width ?? "") + " × " + (root.pageStack.currentItem?.illust?.height ?? "")
+            font.pointSize: 10
+            opacity: 0.7
+            color: Kirigami.Theme.textColor
+        }
+
+        Controls.ToolButton {
+            id: forwardBtn
+            icon.name: "go-next"
+            icon.width: 24
+            icon.height: 24
+            flat: true
+            display: Controls.AbstractButton.IconOnly
+            implicitWidth: 40
+            implicitHeight: 40
+            anchors {
+                right: parent.right
+                verticalCenter: parent.verticalCenter
+                rightMargin: 15
+            }
+            enabled: root.pageStack.currentIndex < root.pageStack.depth - 1 && !root.fullscreenActive
+            onClicked: root.goForward()
         }
 
         Kirigami.AbstractCard {

--- a/src/contents/controls/Sidebar.qml
+++ b/src/contents/controls/Sidebar.qml
@@ -43,7 +43,7 @@ Rectangle {
                         reloadingAccount = false;
                         accountDialog.close();
                         sidebar.collapsed = true;
-                        navigateToPageParm("Welcome", {
+                        navigateToFeed("Welcome", {
                             wkt: walkthrough
                         });
                     });
@@ -93,8 +93,7 @@ Rectangle {
                     onClicked: {
                         loading = true;
                         piqi.RecommendedFeed("illust", true, true).then(recommended => {
-                            // Cache.SynchroniseIllusts(recommended.illusts);
-                            navigateToPageParm("Home", {
+                            navigateToFeed("Home", {
                                 feed: recommended
                             });
                             loading = false;
@@ -113,8 +112,7 @@ Rectangle {
                     onClicked: {
                         loading = true;
                         piqi.FollowingFeed("all").then(following => {
-                            // Cache.SynchroniseIllusts(following.illusts);
-                            navigateToPageParm("Following", {
+                            navigateToFeed("Following", {
                                 feed: following
                             });
                             loading = false;
@@ -129,7 +127,7 @@ Rectangle {
                     onClicked: {
                         loading = true;
                         piqi.WatchlistFeed().then(wtl => {
-                            navigateToPageParm("Watchlist", {
+                            navigateToFeed("Watchlist", {
                                 feed: wtl
                             });
                             loading = false;
@@ -152,7 +150,7 @@ Rectangle {
                         loading = true;
                         piqi.LatestGlobal("illust").then(latest => {
                             // Cache.SynchroniseIllusts(latest.illusts);
-                            navigateToPageParm("Newest", {
+                            navigateToFeed("Newest", {
                                 feed: latest
                             });
                             loading = false;
@@ -173,7 +171,7 @@ Rectangle {
                         loading = true;
                         piqi.BookmarksFeed(null, false).then(bkmarks => {
                             // Cache.SynchroniseIllusts(bkmarks.illusts);
-                            navigateToPageParm("Collection", {
+                            navigateToFeed("Collection", {
                                 feed: bkmarks
                             });
                             loading = false;
@@ -205,7 +203,7 @@ Rectangle {
             onClicked: {
                 loading = true;
                 piqi.Details(piqi.user).then(dtls => {
-                    root.navigateToPageParm("ProfileView", {
+                    root.navigateToFeed("ProfileView", {
                         details: dtls
                     });
                     loading = false;
@@ -227,7 +225,7 @@ Rectangle {
         SidebarButton {
             text: i18n("Settings")
             icon.name: "configure"
-            onClicked: root.navigateToPage("Settings")
+            onClicked: root.navigateToFeed("Settings", {})
         }
     }
 

--- a/src/contents/ui/Main.qml
+++ b/src/contents/ui/Main.qml
@@ -20,6 +20,9 @@ Kirigami.ApplicationWindow {
 
     property string currentPage: pageStack.currentItem?.title ?? ""
     property bool fullscreenActive: false
+    property int _pagesCreated: 0
+    property int _pagesDestroyed: 0
+    property int _pagesAlive: 0
 
     property var _compCache: ({})
 
@@ -27,15 +30,37 @@ Kirigami.ApplicationWindow {
         if (!_compCache[name]) {
             _compCache[name] = Qt.createComponent(name + ".qml", Component.PreferSynchronous);
         }
-        return _compCache[name].createObject(parent, data);
+        let obj = _compCache[name].createObject(parent, data);
+        _pagesCreated++;
+        _pagesAlive++;
+        console.log("[MEM] create", name, "| total created:", _pagesCreated, "| alive:", _pagesAlive, "| depth:", pageStack.depth);
+        return obj;
+    }
+    function _logDestroy(name) {
+        _pagesDestroyed++;
+        _pagesAlive--;
+        console.log("[MEM] destroy", name, "| total destroyed:", _pagesDestroyed, "| alive:", _pagesAlive, "| depth:", pageStack.depth);
     }
     function navigateToPageParm(name, data) {
-        // Trim forward pages before pushing new one
-        while (pageStack.currentIndex < pageStack.depth - 1)
-            pageStack.pop();
+        let oldIdx = pageStack.currentIndex;
+        let doomed = [];
+        for (let i = pageStack.depth - 1; i > oldIdx; i--) {
+            doomed.push(pageStack.get(i));
+        }
         pageStack.push(buildObject(name, data, this));
+        for (let i = 0; i < doomed.length; i++) {
+            _logDestroy(doomed[i].title || "?");
+            doomed[i].destroy();
+        }
     }
     function navigateToFeed(name, data) {
+        for (let i = pageStack.depth - 1; i >= 0; i--) {
+            let page = pageStack.get(i);
+            if (page) {
+                _logDestroy(page.title || "?");
+                page.destroy();
+            }
+        }
         pageStack.clear();
         pageStack.push(buildObject(name, data, this));
     }
@@ -43,12 +68,16 @@ Kirigami.ApplicationWindow {
         navigateToPageParm(name, {});
     }
     function goBack() {
-        if (pageStack.currentIndex > 0)
+        if (pageStack.currentIndex > 0) {
             pageStack.currentIndex--;
+            console.log("[MEM] goBack → idx:", pageStack.currentIndex, "/ depth:", pageStack.depth, "| alive:", _pagesAlive);
+        }
     }
     function goForward() {
-        if (pageStack.currentIndex < pageStack.depth - 1)
+        if (pageStack.currentIndex < pageStack.depth - 1) {
             pageStack.currentIndex++;
+            console.log("[MEM] goForward → idx:", pageStack.currentIndex, "/ depth:", pageStack.depth, "| alive:", _pagesAlive);
+        }
     }
     function loggedIn(response) {
         let json = JSON.parse(response);
@@ -56,8 +85,10 @@ Kirigami.ApplicationWindow {
         LoginHandler.SetUser(json["user"]["account"]).then(() => {
             LoginHandler.WriteToken(json["refresh_token"]).then(() => {
                 LoginHandler.SaveUserToCache(JSON.stringify(json["user"]), piqi).then(() => {
-                    pageStack.pop();
-                    pageStack.pop();
+                    let p1 = pageStack.currentItem; pageStack.pop();
+                    if (p1) { _logDestroy(p1.title || "login"); p1.destroy(); }
+                    let p2 = pageStack.currentItem; pageStack.pop();
+                    if (p2) { _logDestroy(p2.title || "welcome"); p2.destroy(); }
 
                     piqi.RecommendedFeed("illust", true, true).then(recommended => {
                         // Cache.SynchroniseIllusts(recommended.illusts);
@@ -124,6 +155,33 @@ Kirigami.ApplicationWindow {
     pageStack.columnView.columnResizeMode: Kirigami.ColumnView.SingleColumn
     pageStack.columnView.interactive: false
     pageStack.initialPage: Loading {}
+
+    Rectangle {
+        z: 1000
+        anchors { right: parent.right; bottom: parent.bottom; margins: 10 }
+        width: 260; height: 160
+        color: "#CC000000"
+        radius: 6
+
+        Column {
+            anchors { fill: parent; margins: 8 }
+            spacing: 4
+
+            Text { text: "[MEM DEBUG]"; color: "#FF0"; font.bold: true; font.pointSize: 10 }
+            Text { color: "white"; font.pointSize: 9
+                text: "created: " + _pagesCreated + "  destroyed: " + _pagesDestroyed + "  alive: " + _pagesAlive
+            }
+            Text { color: "white"; font.pointSize: 9
+                text: "stack depth: " + pageStack.depth + "  current idx: " + pageStack.currentIndex
+            }
+            Text { color: "white"; font.pointSize: 9
+                text: "current page: " + (pageStack.currentItem?.title ?? "none")
+            }
+            Text { color: "#AAA"; font.pointSize: 8
+                text: "component cache: " + Object.keys(_compCache).length
+            }
+        }
+    }
 
     function showFullscreen(metaPages, metaSinglePage, pageCount) {
         if (root.fullscreenActive)

--- a/src/contents/ui/Main.qml
+++ b/src/contents/ui/Main.qml
@@ -16,28 +16,44 @@ Kirigami.ApplicationWindow {
     title: i18n("Piki")
     minimumWidth: Kirigami.Units.gridUnit * 20
     minimumHeight: Kirigami.Units.gridUnit * 20
-    pageStack.anchors.leftMargin: sidebar.x + 250
+    pageStack.anchors.leftMargin: sidebar.layoutWidth
 
     property string currentPage: pageStack.currentItem?.title ?? ""
+    property bool fullscreenActive: false
+
+    property var _compCache: ({})
 
     function buildObject(name, data, parent) {
-        let comp = Qt.createComponent(name + ".qml");
-        let obj = comp.createObject(parent, data);
-        return obj;
+        if (!_compCache[name]) {
+            _compCache[name] = Qt.createComponent(name + ".qml", Component.PreferSynchronous);
+        }
+        return _compCache[name].createObject(parent, data);
     }
     function navigateToPageParm(name, data) {
+        // Trim forward pages before pushing new one
+        while (pageStack.currentIndex < pageStack.depth - 1)
+            pageStack.pop();
+        pageStack.push(buildObject(name, data, this));
+    }
+    function navigateToFeed(name, data) {
+        pageStack.clear();
         pageStack.push(buildObject(name, data, this));
     }
     function navigateToPage(name) {
         navigateToPageParm(name, {});
     }
+    function goBack() {
+        if (pageStack.currentIndex > 0)
+            pageStack.currentIndex--;
+    }
+    function goForward() {
+        if (pageStack.currentIndex < pageStack.depth - 1)
+            pageStack.currentIndex++;
+    }
     function loggedIn(response) {
         let json = JSON.parse(response);
         piqi.SetLogin(json["access_token"], json["refresh_token"]);
         LoginHandler.SetUser(json["user"]["account"]).then(() => {
-            if (!LoginHandler.keyringProviderInstalled)
-                return;
-
             LoginHandler.WriteToken(json["refresh_token"]).then(() => {
                 LoginHandler.SaveUserToCache(JSON.stringify(json["user"]), piqi).then(() => {
                     pageStack.pop();
@@ -81,7 +97,7 @@ Kirigami.ApplicationWindow {
     }
     header: Header {
         id: hd
-        visible: !sidebar.collapsed
+        visible: true
     }
     function getHeaderQuery() {
         const tgs = hd.selectedTags;
@@ -93,7 +109,7 @@ Kirigami.ApplicationWindow {
     }
 
     Kirigami.Separator {
-        visible: !sidebar.collapsed
+        visible: true
         anchors.top: parent.top
         anchors.left: parent.left
         anchors.right: parent.right
@@ -106,7 +122,44 @@ Kirigami.ApplicationWindow {
 
     pageStack.globalToolBar.style: Kirigami.ApplicationHeaderStyle.None
     pageStack.columnView.columnResizeMode: Kirigami.ColumnView.SingleColumn
+    pageStack.columnView.interactive: false
     pageStack.initialPage: Loading {}
+
+    function showFullscreen(metaPages, metaSinglePage, pageCount) {
+        if (root.fullscreenActive)
+            return;
+        root.fullscreenActive = true;
+
+        let comp = Qt.createComponent("FullscreenView.qml");
+        let create = function() {
+            let item = comp.createObject(root, {
+                z: 999,
+                metaPages: metaPages,
+                metaSinglePage: metaSinglePage,
+                pageCount: pageCount
+            });
+            if (!item) {
+                root.fullscreenActive = false;
+                return;
+            }
+            item.x = 0;
+            item.y = root.header.height;
+            item.width = Qt.binding(function() { return root.width; });
+            item.height = Qt.binding(function() { return root.height - root.header.height; });
+            item.onClose = function() { root.fullscreenActive = false; };
+        };
+        if (comp.status === Component.Ready)
+            create();
+        else if (comp.status === Component.Error)
+            root.fullscreenActive = false;
+        else
+            comp.statusChanged.connect(function() {
+                if (comp.status === Component.Ready)
+                    create();
+                else if (comp.status === Component.Error)
+                    root.fullscreenActive = false;
+            });
+    }
 
     Kirigami.Dialog {
         id: shareDialog

--- a/src/contents/ui/Main.qml
+++ b/src/contents/ui/Main.qml
@@ -64,6 +64,10 @@ Kirigami.ApplicationWindow {
         pageStack.clear();
         pageStack.push(buildObject(name, data, this));
     }
+    function navigateToFeed(name, data) {
+        pageStack.clear();
+        pageStack.push(buildObject(name, data, this));
+    }
     function navigateToPage(name) {
         navigateToPageParm(name, {});
     }


### PR DESCRIPTION
Current behavior
When a new page is opened, a new object is created on the current page object. This makes it easy to quickly navigate back to the previous page, the page before that, and so on. However, if a different page is then opened from one of those previous pages, the originally opened page becomes unreachable—yet it remains in memory without being released, causing a memory leak. The same issue exists with the home button implementation.

Improvements
Only a single linear chain is kept in the object tree; any obsolete branches are destroyed. In addition, when the home button is pressed, the entire object tree is destroyed and re-initialized.

Note
This code was developed with deepseek and has been tested on my fork. However, my fork includes other modifications, so I am not certain whether it can be directly applied upstream.