### PR TITLE
Add forward/back navigation buttons to toolbar and disable swipe gesture

### DIFF
--- a/src/contents/controls/Header.qml
+++ b/src/contents/controls/Header.qml
@@ -94,15 +94,45 @@ Item {
         anchors.leftMargin: 15
         anchors.margins: 5
 
-        Controls.Label {
-            id: headerLabel
+        RowLayout {
             anchors {
                 left: parent.left
                 verticalCenter: parent.verticalCenter
             }
-            text: root.currentPage
-            font.bold: true
-            font.pointSize: 14
+            spacing: 2
+
+            Controls.Button {
+                icon.name: "go-previous"
+                icon.width: 24
+                icon.height: 24
+                flat: true
+                implicitWidth: 40
+                implicitHeight: 40
+                enabled: root._navIndex > 0
+                onClicked: root.goBack()
+            }
+            Controls.Label {
+                id: headerLabel
+                text: root.currentPage
+                font.bold: true
+                font.pointSize: 14
+            }
+        }
+
+        Controls.Button {
+            icon.name: "go-next"
+            icon.width: 24
+            icon.height: 24
+            flat: true
+            implicitWidth: 40
+            implicitHeight: 40
+            anchors {
+                right: parent.right
+                verticalCenter: parent.verticalCenter
+                rightMargin: 15
+            }
+            enabled: root._navIndex < root._navHistory.length - 1
+            onClicked: root.goForward()
         }
 
         Kirigami.AbstractCard {

--- a/src/contents/controls/Sidebar.qml
+++ b/src/contents/controls/Sidebar.qml
@@ -81,6 +81,8 @@ Rectangle {
             Controls.ScrollBar.vertical.policy: Controls.ScrollBar.AlwaysOff
             Controls.ScrollBar.horizontal.policy: Controls.ScrollBar.AlwaysOff
 
+            Component.onCompleted: contentItem.interactive = false
+
             ColumnLayout {
                 id: column
                 width: scrollView.width

--- a/src/contents/ui/Main.qml
+++ b/src/contents/ui/Main.qml
@@ -16,9 +16,11 @@ Kirigami.ApplicationWindow {
     title: i18n("Piki")
     minimumWidth: Kirigami.Units.gridUnit * 20
     minimumHeight: Kirigami.Units.gridUnit * 20
-    pageStack.anchors.leftMargin: sidebar.x + 250
+    pageStack.anchors.leftMargin: sidebar.width
 
     property string currentPage: pageStack.currentItem?.title ?? ""
+    property var _navHistory: []
+    property int _navIndex: -1
 
     function buildObject(name, data, parent) {
         let comp = Qt.createComponent(name + ".qml");
@@ -26,22 +28,44 @@ Kirigami.ApplicationWindow {
         return obj;
     }
     function navigateToPageParm(name, data) {
+        if (_navIndex < _navHistory.length - 1)
+            _navHistory = _navHistory.slice(0, _navIndex + 1);
+        _navHistory.push({name: name, data: data});
+        _navIndex = _navHistory.length - 1;
+        pageStack.push(buildObject(name, data, this));
+    }
+    function navigateToFeed(name, data) {
+        _navHistory = [{name: name, data: data}];
+        _navIndex = 0;
+        pageStack.clear();
         pageStack.push(buildObject(name, data, this));
     }
     function navigateToPage(name) {
         navigateToPageParm(name, {});
     }
+    function goBack() {
+        if (_navIndex > 0) {
+            _navIndex--;
+            pageStack.pop();
+        }
+    }
+    function goForward() {
+        if (_navIndex < _navHistory.length - 1) {
+            _navIndex++;
+            let entry = _navHistory[_navIndex];
+            pageStack.push(buildObject(entry.name, entry.data, this));
+        }
+    }
     function loggedIn(response) {
         let json = JSON.parse(response);
         piqi.SetLogin(json["access_token"], json["refresh_token"]);
         LoginHandler.SetUser(json["user"]["account"]).then(() => {
-            if (!LoginHandler.keyringProviderInstalled)
-                return;
-
             LoginHandler.WriteToken(json["refresh_token"]).then(() => {
                 LoginHandler.SaveUserToCache(JSON.stringify(json["user"]), piqi).then(() => {
                     pageStack.pop();
                     pageStack.pop();
+                    _navHistory = [];
+                    _navIndex = -1;
 
                     piqi.RecommendedFeed("illust", true, true).then(recommended => {
                         // Cache.SynchroniseIllusts(recommended.illusts);
@@ -81,7 +105,7 @@ Kirigami.ApplicationWindow {
     }
     header: Header {
         id: hd
-        visible: !sidebar.collapsed
+        visible: true
     }
     function getHeaderQuery() {
         const tgs = hd.selectedTags;
@@ -93,7 +117,7 @@ Kirigami.ApplicationWindow {
     }
 
     Kirigami.Separator {
-        visible: !sidebar.collapsed
+        visible: true
         anchors.top: parent.top
         anchors.left: parent.left
         anchors.right: parent.right
@@ -106,6 +130,7 @@ Kirigami.ApplicationWindow {
 
     pageStack.globalToolBar.style: Kirigami.ApplicationHeaderStyle.None
     pageStack.columnView.columnResizeMode: Kirigami.ColumnView.SingleColumn
+    pageStack.columnView.interactive: false
     pageStack.initialPage: Loading {}
 
     Kirigami.Dialog {

--- a/src/contents/ui/Main.qml
+++ b/src/contents/ui/Main.qml
@@ -60,9 +60,6 @@ Kirigami.ApplicationWindow {
         let json = JSON.parse(response);
         piqi.SetLogin(json["access_token"], json["refresh_token"]);
         LoginHandler.SetUser(json["user"]["account"]).then(() => {
-            if (!LoginHandler.keyringProviderInstalled)
-                return;
-
             LoginHandler.WriteToken(json["refresh_token"]).then(() => {
                 LoginHandler.SaveUserToCache(JSON.stringify(json["user"]), piqi).then(() => {
                     pageStack.pop();
@@ -108,7 +105,7 @@ Kirigami.ApplicationWindow {
     }
     header: Header {
         id: hd
-        visible: !sidebar.collapsed
+        visible: true
     }
     function getHeaderQuery() {
         const tgs = hd.selectedTags;
@@ -120,7 +117,7 @@ Kirigami.ApplicationWindow {
     }
 
     Kirigami.Separator {
-        visible: !sidebar.collapsed
+        visible: true
         anchors.top: parent.top
         anchors.left: parent.left
         anchors.right: parent.right

--- a/src/contents/ui/Main.qml
+++ b/src/contents/ui/Main.qml
@@ -60,6 +60,9 @@ Kirigami.ApplicationWindow {
         let json = JSON.parse(response);
         piqi.SetLogin(json["access_token"], json["refresh_token"]);
         LoginHandler.SetUser(json["user"]["account"]).then(() => {
+            if (!LoginHandler.keyringProviderInstalled)
+                return;
+
             LoginHandler.WriteToken(json["refresh_token"]).then(() => {
                 LoginHandler.SaveUserToCache(JSON.stringify(json["user"]), piqi).then(() => {
                     pageStack.pop();

--- a/src/contents/ui/Main.qml
+++ b/src/contents/ui/Main.qml
@@ -60,6 +60,9 @@ Kirigami.ApplicationWindow {
         let json = JSON.parse(response);
         piqi.SetLogin(json["access_token"], json["refresh_token"]);
         LoginHandler.SetUser(json["user"]["account"]).then(() => {
+            if (!LoginHandler.keyringProviderInstalled)
+                return;
+
             LoginHandler.WriteToken(json["refresh_token"]).then(() => {
                 LoginHandler.SaveUserToCache(JSON.stringify(json["user"]), piqi).then(() => {
                     pageStack.pop();
@@ -105,7 +108,7 @@ Kirigami.ApplicationWindow {
     }
     header: Header {
         id: hd
-        visible: true
+        visible: !sidebar.collapsed
     }
     function getHeaderQuery() {
         const tgs = hd.selectedTags;
@@ -117,7 +120,7 @@ Kirigami.ApplicationWindow {
     }
 
     Kirigami.Separator {
-        visible: true
+        visible: !sidebar.collapsed
         anchors.top: parent.top
         anchors.left: parent.left
         anchors.right: parent.right


### PR DESCRIPTION
Add go-previous/go-next buttons to the header toolbar for forward/back navigation using pageStack.currentIndex. Disable swipe gesture on pageStack.columnView to avoid touch conflict on Windows where swipe-to-navigate works randomly.